### PR TITLE
Fix #48 : Vec2 - getOpposite shouldn't take an argument

### DIFF
--- a/src/vec2.ts
+++ b/src/vec2.ts
@@ -32,8 +32,8 @@ function create(_x: number, _y: number): Vec2 {
     return Math.sqrt(x * x + y * y)
   }
 
-  const getOpposite = (v: Vec2): Vec2 => {
-    return create(-v.x, -v.y)
+  const getOpposite = (): Vec2 => {
+    return create(-x, -y)
   }
 
   const getPerp = (): Vec2 => {


### PR DESCRIPTION
Hello @erikwatson,
Hope you're doing well.
As it has been requested in the issue #48, I have eliminated the input parameter of getOpposite function in the vec2.ts file.
Additionally, I have simply returned the opposite of its existing value.
If at all I misunderstood something or implemented anything incorrectly, then do let me know.
Sincere apologies for my mistakes if you find any.

Thanks and Regards,
Mohit Kambli